### PR TITLE
Correct next step in 'no token' error message

### DIFF
--- a/src/CL/SlackCli/Command/AbstractApiCommand.php
+++ b/src/CL/SlackCli/Command/AbstractApiCommand.php
@@ -97,7 +97,7 @@ abstract class AbstractApiCommand extends AbstractCommand
             throw new \RuntimeException(
                 'No token provided by `--token` option and no value for `default_token` was found '.
                 'in the global configuration. Use the `--token` option or set the token globally '.
-                'by running `slack.phar config.set default_token your-token-here`'
+                'by running `slack.phar config:set default_token your-token-here`'
             );
         }
         


### PR DESCRIPTION
When I tried my very first command, this error message was super helpful, except that its suggested command had a typo. It works with a colon in config:set.

This PR fixes that one character.
